### PR TITLE
ci: migrate to debian based python slim to save on build time

### DIFF
--- a/Dockerfile.logs-publish
+++ b/Dockerfile.logs-publish
@@ -8,19 +8,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# Build gnumktemp in favor of busybox mktemp
-FROM alpine:3.12 as mktempbuilder
-WORKDIR /tmp/build
-RUN apk add --update --no-cache build-base linux-headers
-RUN wget https://www.mktemp.org/dist/mktemp-1.7.tar.gz \
-  && tar -xzvf mktemp-1.7.tar.gz \
-  && cd mktemp-1.7 \
-  && wget "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD" -O config.guess \
-  && wget "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD" -O config.sub \
-  && ./configure \
-  && make install
-
-FROM python:3-alpine
+FROM python:3.9-slim
 
 # updating to match EGP v0.60.5
 ARG GLOBAL_JJB_COMMIT=53f811d91411bf26a4acf00a9244c6ea0f4510d5
@@ -28,14 +16,6 @@ ARG GLOBAL_JJB_COMMIT=53f811d91411bf26a4acf00a9244c6ea0f4510d5
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
   copyright='Copyright (c) 2020: Intel' \
   maintainer="Ernesto Ojeda <ernesto.ojeda@intel.com>"
-
-RUN mv /bin/mktemp /bin/mktemp-busybox
-COPY --from=mktempbuilder /usr/local/bin/mktemp /usr/local/bin/mktemp
-
-# Currently a python issue with setuptools, this is a workaround
-# https://github.com/pypa/setuptools/issues/2355
-ENV SETUPTOOLS_USE_DISTUTILS="stdlib"
-ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
 
 # Needed for certain lf scripts
 COPY ./lf-env.sh /root/lf-env.sh
@@ -45,11 +25,8 @@ COPY ./lf-env.sh /root/lf-env.sh
 # for container to process sar reports on host. However, there is a technique
 # we can use with sadf to convert between different versions of sar formats.
 # See: https://serverfault.com/questions/757771/how-to-read-sar-file-from-different-ubuntu-system
-RUN apk add --update --no-cache \
-  build-base openssl-dev libxml2-dev \
-  libxslt-dev libffi-dev linux-headers \
-  xmlstarlet bash git util-linux sysstat \
-  sudo jq bash curl \
+RUN apt-get update && apt-get install -y \
+  xmlstarlet git util-linux sysstat sudo jq build-essential \
 
   && adduser --uid 1001 jenkins --disabled-password \
 
@@ -60,6 +37,8 @@ RUN apk add --update --no-cache \
   && pip3 install --no-cache-dir --upgrade pip setuptools \
   && pip3 install --no-cache-dir -I lftools[openstack]==0.31.1 \
   && pip3 install --no-cache-dir zipp==1.1.0 python-openstackclient \
+
+  && apt-get remove -y build-essential && apt autoremove -y \
 
   && git clone https://github.com/lfit/releng-global-jjb.git global-jjb \
   && cd global-jjb \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
             parallel {
                 stage('amd64') {
                     agent {
-                        label 'centos7-docker-4c-2g'
+                        label 'centos7-docker-8c-8g'
                     }
                     stages {
                         stage('Docker Build') {
@@ -56,15 +56,15 @@ pipeline {
                             when { expression { env.GIT_BRANCH == 'lftools' } }
                             steps {
                                 script {
-                                    docker.withRegistry("https://${env.DOCKER_REGISTRY}:10003") {
+                                    docker.withRegistry("https://${env.DOCKER_REGISTRY}:10003/edgex-devops") {
                                         image.push("latest")
                                         image.push(env.GIT_COMMIT)
                                         image.push("0.31.1-centos7")
                                     }
 
-                                    docker.withRegistry("https://${env.DOCKER_REGISTRY}:10003") {
-                                        logImage_amd64.push("alpine")
-                                        logImage_amd64.push("0.31.1-alpine")
+                                    docker.withRegistry("https://${env.DOCKER_REGISTRY}:10003/edgex-devops") {
+                                        logImage_amd64.push("latest")
+                                        logImage_amd64.push("0.31.1-slim")
                                         logImage_amd64.push("amd64")
                                         logImage_amd64.push("x86_64")
                                     }
@@ -92,7 +92,7 @@ pipeline {
                             when { expression { env.GIT_BRANCH == 'lftools' } }
                             steps {
                                 script {
-                                    docker.withRegistry("https://${env.DOCKER_REGISTRY}:10003") {
+                                    docker.withRegistry("https://${env.DOCKER_REGISTRY}:10003/edgex-devops") {
                                         logImage_arm64.push("arm64")
                                         logImage_arm64.push("aarch64")
                                     }


### PR DESCRIPTION
Due to alpine based images not having pre-built wheels for musl based python dependencies, the current build require compilation of c based libraries. This leads to a long build times, error prone and hard to reproduce docker images. This PR switches to the `python:3.9-slim` base docker image which is debian based and is actually smaller, easier and more consistent to build.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
