### PR TITLE
feat: add spire binaries into base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.17.6-alpine3.15
+FROM golang:1.17.7-alpine3.15
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2020: Intel Corporation'
@@ -23,3 +23,16 @@ RUN apk add --update --no-cache make git curl bash zeromq-dev libsodium-dev pkgc
     && ln -s /bin/touch /usr/bin/touch \
     && wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v${GOLANGCI_VERSION}
 
+ARG SPIRE_RELEASE=1.2.1
+
+# build spire from the source in order to be compatible with arch arm64 as well
+WORKDIR /edgex-go/spire-build
+
+RUN wget -q "https://github.com/spiffe/spire/archive/refs/tags/v${SPIRE_RELEASE}.tar.gz" && \
+    tar xv --strip-components=1 -f "v${SPIRE_RELEASE}.tar.gz"
+
+RUN echo "building spire from source..." && \
+    make bin/spire-server bin/spire-agent && \
+    cp bin/spire* /usr/local/bin/
+
+WORKDIR /


### PR DESCRIPTION
Compiling spire binaries into the main go image.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
