### PR TITLE
ci: Migrate golangci-lint configuration file from v1 to v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,22 +1,26 @@
-run:
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 120s
-
-issues:
-  exclude-files:
-    - doc.go
-
+version: "2"
 linters:
   enable:
-    - govet
-    - errcheck
-    - staticcheck
-    - unused
-    - ineffassign
-    - typecheck
-    - unparam
-    - unconvert
-    - misspell
     - goconst
-  disable:
-    - gosimple
+    - misspell
+    - unconvert
+    - unparam
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - doc.go
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2020-2023: Intel Corporation'
 
 ENV HADOLINT_VERSION=2.14.0 \
-    GOLANGCI_VERSION=1.64.8
+    GOLANGCI_VERSION=2.5.0
 
 COPY ./.golangci.yml /etc/.golangci.yml
 


### PR DESCRIPTION
Covert the file by golangci-lint CLI with command `golangci-lint migrate -c .golangci.yml`
Reference doc: https://golangci-lint.run/docs/product/migration-guide/

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
